### PR TITLE
Migrate package references to r-lib

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Description: R binding for 'libfswatch', a file system monitoring library. Watch
     files, or directories recursively, for changes in the background. Log
     activity, or trigger an R function to run every time an event occurs. 
 License: MIT + file LICENSE
-BugReports: https://github.com/shikokuchuo/watcher/issues
-URL: https://shikokuchuo.net/watcher/, https://github.com/shikokuchuo/watcher/
+BugReports: https://github.com/r-lib/watcher/issues
+URL: https://r-lib.github.io/watcher/, https://github.com/r-lib/watcher/
 Encoding: UTF-8
 SystemRequirements: 'libfswatch', or 'cmake' to compile from package sources
 Depends: 

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,8 +16,8 @@ knitr::opts_chunk$set(
 # watcher
 
 <!-- badges: start -->
-[![R-CMD-check](https://github.com/shikokuchuo/watcher/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/shikokuchuo/watcher/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/shikokuchuo/watcher/graph/badge.svg)](https://app.codecov.io/gh/shikokuchuo/watcher)
+[![R-CMD-check](https://github.com/r-lib/watcher/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/watcher/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/r-lib/watcher/graph/badge.svg)](https://app.codecov.io/gh/r-lib/watcher)
 <!-- badges: end -->
 
 Watch the File System for Changes
@@ -40,7 +40,7 @@ Watching is done asynchronously in the background, without blocking the session.
 You can install the development version of watcher from:
 
 ``` r
-pak::pak("shikokuchuo/watcher")
+pak::pak("r-lib/watcher")
 ```
 
 #### Installation from Source

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/shikokuchuo/watcher/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/shikokuchuo/watcher/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/r-lib/watcher/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/watcher/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/shikokuchuo/watcher/graph/badge.svg)](https://app.codecov.io/gh/shikokuchuo/watcher)
+coverage](https://codecov.io/gh/r-lib/watcher/graph/badge.svg)](https://app.codecov.io/gh/r-lib/watcher)
 <!-- badges: end -->
 
 Watch the File System for Changes
@@ -33,7 +33,7 @@ session.
 You can install the development version of watcher from:
 
 ``` r
-pak::pak("shikokuchuo/watcher")
+pak::pak("r-lib/watcher")
 ```
 
 #### Installation from Source
@@ -70,7 +70,7 @@ w
 #> <Watcher>
 #>   Public:
 #>     initialize: function (path, callback, latency) 
-#>     path: /tmp/RtmpgUPHtI/watcher-example
+#>     path: /tmp/RtmpoVr77F/watcher-example
 #>     running: FALSE
 #>     start: function () 
 #>     stop: function () 
@@ -84,19 +84,19 @@ file.create(file.path(dir, "newfile"))
 file.create(file.path(dir, "anotherfile"))
 #> [1] TRUE
 later::run_now(1)
-#> [1] "/tmp/RtmpgUPHtI/watcher-example/newfile"
-#> [1] "/tmp/RtmpgUPHtI/watcher-example/anotherfile"
+#> [1] "/tmp/RtmpoVr77F/watcher-example/newfile"
+#> [1] "/tmp/RtmpoVr77F/watcher-example/anotherfile"
 
 newfile <- file(file.path(dir, "newfile"), open = "r+")
 cat("hello", file = newfile)
 close(newfile)
 later::run_now(1)
-#> [1] "/tmp/RtmpgUPHtI/watcher-example/newfile"
+#> [1] "/tmp/RtmpoVr77F/watcher-example/newfile"
 
 file.remove(file.path(dir, "newfile"))
 #> [1] TRUE
 later::run_now(1)
-#> [1] "/tmp/RtmpgUPHtI/watcher-example/newfile"
+#> [1] "/tmp/RtmpoVr77F/watcher-example/newfile"
 
 w$stop()
 unlink(dir, recursive = TRUE, force = TRUE)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,3 @@
-url: http://shikokuchuo.net/watcher/
+url: https://r-lib.github.io/watcher/
 template:
   bootstrap: 5
-

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# uses: https://github.com/shikokuchuo/fswatch/commit/a37be38dd4dbb7e6397ea4847bf2a80f00ed4747
+# bundled source: https://github.com/shikokuchuo/fswatch/commit/a37be38dd4dbb7e6397ea4847bf2a80f00ed4747
 LIB_VER="1.18.2"
 
 # Initialise

--- a/man/watcher-package.Rd
+++ b/man/watcher-package.Rd
@@ -10,9 +10,9 @@ R binding for 'libfswatch', a file system monitoring library. Watch files, or di
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://shikokuchuo.net/watcher/}
-  \item \url{https://github.com/shikokuchuo/watcher/}
-  \item Report bugs at \url{https://github.com/shikokuchuo/watcher/issues}
+  \item \url{https://r-lib.github.io/watcher/}
+  \item \url{https://github.com/r-lib/watcher/}
+  \item Report bugs at \url{https://github.com/r-lib/watcher/issues}
 }
 
 }


### PR DESCRIPTION
Due to package transfer from `shikokuchuo` to the `r-lib` organization.