### PR TITLE
Update configure to support old tar versions

### DIFF
--- a/configure
+++ b/configure
@@ -74,7 +74,7 @@ if [ -z "$PKG_CFLAGS" ]; then
       exit 1
     fi
   fi
-  tar -xf src/fswatch-$LIB_VER.tar.gz
+  gzip -dc src/fswatch-$LIB_VER.tar.gz | tar -xf -
   cd fswatch-$LIB_VER
   cmake -DCMAKE_INSTALL_PREFIX=../install \
   -DBUILD_LIBS_ONLY=1 -DUSE_NLS=0 -DCMAKE_POSITION_INDEPENDENT_CODE=1 \

--- a/configure.win
+++ b/configure.win
@@ -6,7 +6,7 @@ CC=`"${R_HOME}/bin/R" CMD config CC`
 export CC
 
 echo "Compiling 'libfswatch' from source..."
-tar -xf src/fswatch-$LIB_VER.tar.gz
+gzip -dc src/fswatch-$LIB_VER.tar.gz | tar -xf -
 cd fswatch-$LIB_VER
 cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=../install \
   -DBUILD_LIBS_ONLY=1 -DUSE_NLS=0 -DCMAKE_POSITION_INDEPENDENT_CODE=1 \


### PR DESCRIPTION
Likely only relevant for Solaris (i.e. SunOS 5.10), but `libfswatch` does support Solaris...