### PR TITLE
Update bundled libfswatch to 1.20.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # watcher (development version)
 
+* Updates bundled 'libfswatch' source to 1.20.1 release.
+
 # watcher 0.1.5
 
 * Fixed issue on Windows where watching with a `latency` < 1 caused high CPU usage (#32, thanks @RichardHooijmaijers).

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ install.packages("watcher")
 watcher requires the 'libfswatch' library.
 
 - On Linux / MacOS, an installed version will be used if found in the standard filesystem locations.
-- On Windows, or if not found, the bundled version of 'libfswatch' 1.19.0-dev will be compiled from source.
+- On Windows, or if not found, the bundled version of 'libfswatch' 1.20.1 will be compiled from source.
 - Source compilation of the library requires 'cmake'.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ watcher requires the ‘libfswatch’ library.
 - On Linux / MacOS, an installed version will be used if found in the
   standard filesystem locations.
 - On Windows, or if not found, the bundled version of ‘libfswatch’
-  1.19.0-dev will be compiled from source.
+  1.20.1 will be compiled from source.
 - Source compilation of the library requires ‘cmake’.
 
 ## Quick Start
@@ -82,7 +82,7 @@ w
 #>     start: function () 
 #>     stop: function () 
 #>   Private:
-#>     path: /var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T//RtmpFm ...
+#>     path: /var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T//Rtmp3X ...
 #>     running: FALSE
 #>     watch: externalptr
 w$start()
@@ -92,20 +92,20 @@ file.create(file.path(dir, "newfile"))
 file.create(file.path(dir, "anotherfile"))
 #> [1] TRUE
 later::run_now(1)
-#> [1] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/RtmpFmlhtZ/watcher-example"            
-#> [2] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/RtmpFmlhtZ/watcher-example/newfile"    
-#> [3] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/RtmpFmlhtZ/watcher-example/anotherfile"
+#> [1] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/Rtmp3XW7UO/watcher-example"            
+#> [2] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/Rtmp3XW7UO/watcher-example/newfile"    
+#> [3] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/Rtmp3XW7UO/watcher-example/anotherfile"
 
 newfile <- file(file.path(dir, "newfile"), open = "r+")
 cat("hello", file = newfile)
 close(newfile)
 later::run_now(1)
-#> [1] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/RtmpFmlhtZ/watcher-example/newfile"
+#> [1] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/Rtmp3XW7UO/watcher-example/newfile"
 
 file.remove(file.path(dir, "newfile"))
 #> [1] TRUE
 later::run_now(1)
-#> [1] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/RtmpFmlhtZ/watcher-example/newfile"
+#> [1] "/private/var/folders/38/lgkw9s3d5tn626g4z2r11bzm0000gp/T/Rtmp3XW7UO/watcher-example/newfile"
 
 w$stop()
 unlink(dir, recursive = TRUE, force = TRUE)

--- a/src/fswatch/CMakeLists.txt
+++ b/src/fswatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2025 Enrico M. Crisostomo
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -14,9 +14,9 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 cmake_minimum_required(VERSION 3.14)
-project(fswatch VERSION 1.19.0 LANGUAGES C CXX)
+project(fswatch VERSION 1.20.1 LANGUAGES C CXX)
 
-set(VERSION_MODIFIER "-develop")
+set(VERSION_MODIFIER "")
 set(FULL_VERSION "${PROJECT_VERSION}${VERSION_MODIFIER}")
 
 #@formatter:off
@@ -48,6 +48,7 @@ include(FindIntl)
 include(CheckIncludeFileCXX)
 include(CheckStructHasMember)
 include(CheckCXXSymbolExists)
+include(CTest)
 
 # check for gettext and libintl
 check_include_file_cxx(getopt.h HAVE_GETOPT_H)

--- a/src/fswatch/README.md
+++ b/src/fswatch/README.md
@@ -173,6 +173,10 @@ developer, (ii) you have the GNU Build System installed on your machine, and
 
 CMake-support is unofficially offered as a courtesy.
 
+On Windows, MSYS2 with a MinGW-w64 toolchain is the recommended build
+environment.  Cygwin builds are kept for compatibility, but Cygwin is not
+required to build `fswatch` on Windows.  See `README.windows` for details.
+
 [release]: https://github.com/emcrisostomo/fswatch/releases
 
 Installation

--- a/src/fswatch/libfswatch/CMakeLists.txt
+++ b/src/fswatch/libfswatch/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2025 Enrico M. Crisostomo
+# Copyright (c) 2014-2026 Enrico M. Crisostomo
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -78,15 +78,62 @@ check_struct_has_member("struct stat" st_mtime sys/stat.h HAVE_STRUCT_STAT_ST_MT
 check_struct_has_member("struct stat" st_mtimespec sys/stat.h HAVE_STRUCT_STAT_ST_MTIMESPEC)
 
 check_include_file_cxx(sys/inotify.h HAVE_SYS_INOTIFY_H)
+check_include_file_cxx(sys/epoll.h HAVE_SYS_EPOLL_H)
+check_include_file_cxx(sys/eventfd.h HAVE_SYS_EVENTFD_H)
 
-if (HAVE_SYS_INOTIFY_H)
+if (HAVE_SYS_INOTIFY_H AND HAVE_SYS_EPOLL_H AND HAVE_SYS_EVENTFD_H)
+    set(CMAKE_REQUIRED_DEFINITIONS_SAVED ${CMAKE_REQUIRED_DEFINITIONS})
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    check_cxx_symbol_exists(inotify_init1 sys/inotify.h HAVE_INOTIFY_INIT1)
+    check_cxx_symbol_exists(epoll_create1 sys/epoll.h HAVE_EPOLL_CREATE1)
+    check_cxx_symbol_exists(eventfd sys/eventfd.h HAVE_EVENTFD)
+    set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS_SAVED})
+endif ()
+
+if (HAVE_SYS_INOTIFY_H AND HAVE_SYS_EPOLL_H AND HAVE_SYS_EVENTFD_H AND
+        HAVE_INOTIFY_INIT1 AND HAVE_EPOLL_CREATE1 AND HAVE_EVENTFD)
+    set(HAVE_INOTIFY_MONITOR 1 CACHE INTERNAL "Linux inotify monitor is available")
     set(LIBFSWATCH_HEADER_FILES
             ${LIBFSWATCH_HEADER_FILES}
             src/libfswatch/c++/inotify_monitor.hpp)
     set(LIB_SOURCE_FILES
             ${LIB_SOURCE_FILES}
             src/libfswatch/c++/inotify_monitor.cpp)
-endif (HAVE_SYS_INOTIFY_H)
+endif ()
+
+check_include_file_cxx(sys/fanotify.h HAVE_SYS_FANOTIFY_H)
+check_include_file_cxx(sys/epoll.h HAVE_SYS_EPOLL_H)
+check_include_file_cxx(sys/eventfd.h HAVE_SYS_EVENTFD_H)
+
+if (HAVE_SYS_FANOTIFY_H AND HAVE_SYS_EPOLL_H AND HAVE_SYS_EVENTFD_H)
+    check_cxx_symbol_exists(fanotify_init sys/fanotify.h HAVE_FANOTIFY_INIT)
+    check_cxx_symbol_exists(fanotify_mark sys/fanotify.h HAVE_FANOTIFY_MARK)
+    check_cxx_symbol_exists(epoll_create1 sys/epoll.h HAVE_EPOLL_CREATE1)
+    check_cxx_symbol_exists(epoll_ctl sys/epoll.h HAVE_EPOLL_CTL)
+    check_cxx_symbol_exists(epoll_wait sys/epoll.h HAVE_EPOLL_WAIT)
+    check_cxx_symbol_exists(eventfd sys/eventfd.h HAVE_EVENTFD)
+    check_cxx_symbol_exists(FAN_REPORT_DFID_NAME sys/fanotify.h HAVE_FAN_REPORT_DFID_NAME)
+    check_cxx_symbol_exists(FAN_CREATE sys/fanotify.h HAVE_FAN_CREATE)
+    check_cxx_symbol_exists(FAN_DELETE sys/fanotify.h HAVE_FAN_DELETE)
+    check_cxx_symbol_exists(FAN_MOVED_FROM sys/fanotify.h HAVE_FAN_MOVED_FROM)
+    check_cxx_symbol_exists(FAN_MOVED_TO sys/fanotify.h HAVE_FAN_MOVED_TO)
+    check_cxx_symbol_exists(FAN_EVENT_ON_CHILD sys/fanotify.h HAVE_FAN_EVENT_ON_CHILD)
+    check_cxx_symbol_exists(FAN_Q_OVERFLOW sys/fanotify.h HAVE_FAN_Q_OVERFLOW)
+
+    if (HAVE_FANOTIFY_INIT AND HAVE_FANOTIFY_MARK AND
+        HAVE_EPOLL_CREATE1 AND HAVE_EPOLL_CTL AND HAVE_EPOLL_WAIT AND HAVE_EVENTFD AND
+        HAVE_FAN_REPORT_DFID_NAME AND HAVE_FAN_CREATE AND HAVE_FAN_DELETE AND
+        HAVE_FAN_MOVED_FROM AND HAVE_FAN_MOVED_TO AND
+        HAVE_FAN_EVENT_ON_CHILD AND HAVE_FAN_Q_OVERFLOW)
+        set(HAVE_FANOTIFY ON CACHE BOOL "Enable fanotify support")
+        set(LIBFSWATCH_HEADER_FILES
+                ${LIBFSWATCH_HEADER_FILES}
+                src/libfswatch/c++/fanotify_monitor.hpp)
+        set(LIB_SOURCE_FILES
+                ${LIB_SOURCE_FILES}
+                src/libfswatch/c++/fanotify_monitor.cpp)
+    endif ()
+endif ()
 
 check_include_file_cxx(sys/event.h HAVE_SYS_EVENT_H)
 

--- a/src/fswatch/libfswatch/libfswatch_config.in
+++ b/src/fswatch/libfswatch/libfswatch_config.in
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #cmakedefine ENABLE_NLS        @ENABLE_NLS@
 #cmakedefine LOCALEDIR         "@LOCALEDIR@"
 #cmakedefine PACKAGE           "@PACKAGE@"
@@ -10,10 +26,15 @@
 #cmakedefine HAVE_GETOPT_LONG
 
 #cmakedefine HAVE_FSEVENTS_FSEVENTSTREAMSETDISPATCHQUEUE
+#cmakedefine HAVE_FANOTIFY
 #cmakedefine HAVE_PORT_H
 #cmakedefine HAVE_STRUCT_STAT_ST_MTIME
 #cmakedefine HAVE_STRUCT_STAT_ST_MTIMESPEC
+#cmakedefine HAVE_INOTIFY_MONITOR
+#cmakedefine HAVE_SYS_EPOLL_H
+#cmakedefine HAVE_SYS_EVENTFD_H
 #cmakedefine HAVE_SYS_EVENT_H
+#cmakedefine HAVE_SYS_FANOTIFY_H
 #cmakedefine HAVE_SYS_INOTIFY_H
 #cmakedefine HAVE_WINDOWS
 

--- a/src/fswatch/libfswatch/src/libfswatch/c++/event.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/event.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -32,6 +32,19 @@ namespace fsw
   {
   }
 
+  event::event(string path,
+               time_t evt_time,
+               vector<fsw_event_flag> flags,
+               unsigned long correlation_id,
+               process_metadata process) :
+    path(std::move(path)),
+    evt_time(evt_time),
+    evt_flags(std::move(flags)),
+    correlation_id(correlation_id),
+    process(process)
+  {
+  }
+
   event::~event() = default;
 
   string event::get_path() const
@@ -52,6 +65,46 @@ namespace fsw
   unsigned long event::get_correlation_id() const
   {
     return correlation_id;
+  }
+
+  bool event::has_process_id() const
+  {
+    return process.kind != process_id_kind::none;
+  }
+
+  long long event::get_process_id() const
+  {
+    return process.id;
+  }
+
+  process_id_kind event::get_process_id_kind() const
+  {
+    return process.kind;
+  }
+
+  bool event::has_process_pidfd() const
+  {
+    return process.has_pidfd;
+  }
+
+  int event::get_process_pidfd() const
+  {
+    return process.has_pidfd ? process.pidfd : -1;
+  }
+
+  string event::get_process_id_kind_name(process_id_kind kind)
+  {
+    switch (kind)
+    {
+    case process_id_kind::pid:
+      return "pid";
+    case process_id_kind::tid:
+      return "tid";
+    case process_id_kind::none:
+      return "";
+    }
+
+    return "";
   }
 
   fsw_event_flag event::get_event_flag_by_name(const string& name)

--- a/src/fswatch/libfswatch/src/libfswatch/c++/event.hpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/event.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,7 +17,7 @@
  * @file
  * @brief Header of the fsw::event class.
  *
- * @copyright Copyright (c) 2014-2022 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.18.0
@@ -30,10 +30,26 @@
 #  include <ctime>
 #  include <vector>
 #  include <iostream>
+#  include <optional>
 #  include "../c/cevent.h"
 
 namespace fsw
 {
+  enum class process_id_kind
+  {
+    none = 0,
+    pid,
+    tid
+  };
+
+  struct process_metadata
+  {
+    process_id_kind kind = process_id_kind::none;
+    long long id = 0;
+    int pidfd = -1;
+    bool has_pidfd = false;
+  };
+
   /**
    * @brief Type representing a file change event.
    *
@@ -66,6 +82,21 @@ namespace fsw
      * @param correlation_id The correlation_id of the file the event refers to.
      */
     event(std::string path, time_t evt_time, std::vector<fsw_event_flag> flags, unsigned long correlation_id);
+
+    /**
+     * @brief Constructs an event with optional process metadata.
+     *
+     * @param path The path the event refers to.
+     * @param evt_time The time the event was raised.
+     * @param flags The vector of flags specifying the type of the event.
+     * @param correlation_id The correlation_id of the file the event refers to.
+     * @param process The optional process metadata associated with the event.
+     */
+    event(std::string path,
+          time_t evt_time,
+          std::vector<fsw_event_flag> flags,
+          unsigned long correlation_id,
+          process_metadata process);
 
     /**
      * @brief Destructs an event.
@@ -102,6 +133,42 @@ namespace fsw
     unsigned long get_correlation_id() const;
 
     /**
+     * @brief Returns true if the event has process attribution metadata.
+     */
+    bool has_process_id() const;
+
+    /**
+     * @brief Returns the process or thread identifier associated with this event.
+     *
+     * Returns 0 when no process attribution metadata is available.
+     */
+    long long get_process_id() const;
+
+    /**
+     * @brief Returns the process identifier kind.
+     */
+    process_id_kind get_process_id_kind() const;
+
+    /**
+     * @brief Returns true if the event has a process file descriptor.
+     */
+    bool has_process_pidfd() const;
+
+    /**
+     * @brief Returns the process file descriptor associated with this event.
+     *
+     * Returns -1 when no process file descriptor is available.  The descriptor
+     * is owned by the event producer and is only valid during callback
+     * processing.
+     */
+    int get_process_pidfd() const;
+
+    /**
+     * @brief Get the display name of a process identifier kind.
+     */
+    static std::string get_process_id_kind_name(process_id_kind kind);
+
+    /**
      * @brief Get event flag by name.
      *
      * @param name The name of the event flag to look for.
@@ -124,6 +191,7 @@ namespace fsw
     time_t evt_time;
     std::vector<fsw_event_flag> evt_flags;
     unsigned long correlation_id = 0;
+    process_metadata process;
   };
 
   /**

--- a/src/fswatch/libfswatch/src/libfswatch/c++/fanotify_monitor.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/fanotify_monitor.cpp
@@ -1,0 +1,736 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include <libfswatch/libfswatch_config.h>
+
+#include "fanotify_monitor.hpp"
+#include "libfswatch/gettext_defs.h"
+#include "libfswatch_exception.hpp"
+#include "../c/libfswatch_log.h"
+#include "path_utils.hpp"
+#include "string/string_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+#include <fcntl.h>
+#include <limits.h>
+#include <sstream>
+#include <string>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/fanotify.h>
+#include <sys/stat.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#ifndef O_LARGEFILE
+#  define O_LARGEFILE 0
+#endif
+
+#ifndef MAX_HANDLE_SZ
+#  define MAX_HANDLE_SZ 128
+#endif
+
+namespace fsw
+{
+  namespace
+  {
+    constexpr size_t FANOTIFY_BUFFER_SIZE = 4096;
+    constexpr size_t FILE_HANDLE_BUFFER_SIZE = sizeof(struct file_handle) + MAX_HANDLE_SZ;
+    constexpr int EPOLL_EVENT_COUNT = 2;
+
+    struct scoped_fd
+    {
+      int fd = -1;
+
+      scoped_fd() = default;
+      explicit scoped_fd(int fd) : fd(fd) {}
+      scoped_fd(const scoped_fd&) = delete;
+      scoped_fd& operator=(const scoped_fd&) = delete;
+
+      scoped_fd(scoped_fd&& other) noexcept : fd(other.fd)
+      {
+        other.fd = -1;
+      }
+
+      scoped_fd& operator=(scoped_fd&& other) noexcept
+      {
+        if (this != &other)
+        {
+          reset();
+          fd = other.fd;
+          other.fd = -1;
+        }
+
+        return *this;
+      }
+
+      ~scoped_fd()
+      {
+        reset();
+      }
+
+      void reset(int new_fd = -1)
+      {
+        if (fd >= 0) close(fd);
+        fd = new_fd;
+      }
+
+      int get() const
+      {
+        return fd;
+      }
+    };
+
+    struct handle_buffer
+    {
+      std::array<unsigned char, FILE_HANDLE_BUFFER_SIZE> bytes{};
+
+      struct file_handle *get()
+      {
+        return reinterpret_cast<struct file_handle *>(bytes.data());
+      }
+    };
+
+    static bool string_to_bool(const std::string& value)
+    {
+      return value == "1" || value == "true" || value == "yes" || value == "on";
+    }
+
+    static int latency_to_timeout_ms(double latency)
+    {
+      if (latency <= 0) return 0;
+      if (latency >= INT_MAX / 1000.0) return INT_MAX;
+
+      return static_cast<int>(std::ceil(latency * 1000.0));
+    }
+
+    static void add_epoll_interest(int epoll_fd, int fd)
+    {
+      struct epoll_event event {};
+      event.events = EPOLLIN;
+      event.data.fd = fd;
+
+      if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &event) != 0)
+      {
+        fsw_log_perror("epoll_ctl");
+        throw libfsw_exception(_("Cannot initialize fanotify."));
+      }
+    }
+
+    static void drain_eventfd(int fd)
+    {
+      for (;;)
+      {
+        uint64_t value = 0;
+        ssize_t read_count = read(fd, &value, sizeof(value));
+
+        if (read_count == static_cast<ssize_t>(sizeof(value))) continue;
+        if (read_count == -1 && errno == EINTR) continue;
+        if (read_count == -1 && errno == EAGAIN) break;
+        if (read_count == -1)
+        {
+          fsw_log_perror("read");
+          break;
+        }
+
+        break;
+      }
+    }
+
+    static std::string make_handle_key(const void *fsid,
+                                       size_t fsid_size,
+                                       const struct file_handle *handle)
+    {
+      std::string key;
+      key.append(reinterpret_cast<const char *>(fsid), fsid_size);
+      key.append(reinterpret_cast<const char *>(&handle->handle_type), sizeof(handle->handle_type));
+      key.append(reinterpret_cast<const char *>(&handle->handle_bytes), sizeof(handle->handle_bytes));
+      key.append(reinterpret_cast<const char *>(handle->f_handle), handle->handle_bytes);
+
+      return key;
+    }
+
+    static bool get_path_handle(const std::filesystem::path& path,
+                                std::string& key)
+    {
+      struct statfs fs_stats{};
+      if (statfs(path.c_str(), &fs_stats) != 0)
+      {
+        fsw_log_perror("statfs");
+        return false;
+      }
+
+      handle_buffer buffer;
+      struct file_handle *handle = buffer.get();
+      handle->handle_bytes = MAX_HANDLE_SZ;
+      int mount_id = 0;
+
+      if (name_to_handle_at(AT_FDCWD, path.c_str(), handle, &mount_id, 0) != 0)
+      {
+        fsw_log_perror("name_to_handle_at");
+        return false;
+      }
+
+      key = make_handle_key(&fs_stats.f_fsid, sizeof(fs_stats.f_fsid), handle);
+      return true;
+    }
+
+    static std::vector<fsw_event_flag> flags_from_mask(uint64_t mask)
+    {
+      std::vector<fsw_event_flag> flags;
+
+      if (mask & FAN_ONDIR) flags.push_back(fsw_event_flag::IsDir);
+      if (mask & FAN_CREATE) flags.push_back(fsw_event_flag::Created);
+      if (mask & FAN_MODIFY) flags.push_back(fsw_event_flag::Updated);
+      if (mask & FAN_CLOSE_WRITE) flags.push_back(fsw_event_flag::CloseWrite);
+      if (mask & FAN_ATTRIB) flags.push_back(fsw_event_flag::AttributeModified);
+      if (mask & FAN_DELETE) flags.push_back(fsw_event_flag::Removed);
+      if (mask & FAN_DELETE_SELF) flags.push_back(fsw_event_flag::Removed);
+      if (mask & FAN_MOVED_FROM)
+      {
+        flags.push_back(fsw_event_flag::Removed);
+        flags.push_back(fsw_event_flag::MovedFrom);
+      }
+      if (mask & FAN_MOVED_TO)
+      {
+        flags.push_back(fsw_event_flag::Created);
+        flags.push_back(fsw_event_flag::MovedTo);
+      }
+      if (mask & FAN_MOVE_SELF) flags.push_back(fsw_event_flag::Renamed);
+      if (mask & FAN_ACCESS) flags.push_back(fsw_event_flag::PlatformSpecific);
+      if (mask & FAN_OPEN) flags.push_back(fsw_event_flag::PlatformSpecific);
+      if (mask & FAN_CLOSE_NOWRITE) flags.push_back(fsw_event_flag::PlatformSpecific);
+
+      return flags;
+    }
+
+    static bool is_directory_event(uint64_t mask)
+    {
+      return (mask & FAN_ONDIR) != 0;
+    }
+  }
+
+  struct fanotify_monitor_impl
+  {
+    scoped_fd fanotify_fd;
+    scoped_fd epoll_fd;
+    scoped_fd wake_fd;
+    std::vector<event> events;
+    std::vector<int> pidfds_to_close;
+    std::unordered_set<std::string> watched_paths;
+    std::unordered_map<std::string, std::string> handle_to_path;
+    std::vector<std::string> paths_to_rescan;
+    std::vector<std::string> paths_to_fire_create;
+    process_id_kind process_kind = process_id_kind::pid;
+    bool report_pidfd = false;
+    bool initialized = false;
+    time_t curr_time = 0;
+  };
+
+  fanotify_monitor::fanotify_monitor(std::vector<std::string> paths_to_monitor,
+                                     FSW_EVENT_CALLBACK *callback,
+                                     void *context) :
+    monitor(std::move(paths_to_monitor), callback, context),
+    impl(std::make_unique<fanotify_monitor_impl>())
+  {
+  }
+
+  fanotify_monitor::~fanotify_monitor() = default;
+
+  void fanotify_monitor::initialize()
+  {
+    if (impl->initialized) return;
+
+    const std::string process_id_property = get_property(PROCESS_ID_PROPERTY);
+    if (!process_id_property.empty())
+    {
+      if (process_id_property == "pid")
+      {
+        impl->process_kind = process_id_kind::pid;
+      }
+      else if (process_id_property == "tid")
+      {
+#if defined(FAN_REPORT_TID)
+        impl->process_kind = process_id_kind::tid;
+#else
+        throw libfsw_exception(_("fanotify TID reporting is not supported by the build headers."));
+#endif
+      }
+      else
+      {
+        throw libfsw_exception(_("Invalid fanotify.process-id value."));
+      }
+    }
+
+    impl->report_pidfd = string_to_bool(get_property(REPORT_PIDFD_PROPERTY));
+
+    if (impl->report_pidfd && impl->process_kind == process_id_kind::tid)
+      throw libfsw_exception(_("fanotify.report-pidfd=true is incompatible with fanotify.process-id=tid."));
+
+    unsigned int init_flags = FAN_CLASS_NOTIF | FAN_CLOEXEC | FAN_NONBLOCK | FAN_REPORT_DFID_NAME;
+
+    const bool unlimited_queue = string_to_bool(get_property(UNLIMITED_QUEUE_PROPERTY));
+    const bool unlimited_marks = string_to_bool(get_property(UNLIMITED_MARKS_PROPERTY));
+
+    if (unlimited_queue)
+    {
+#if defined(FAN_UNLIMITED_QUEUE)
+      init_flags |= FAN_UNLIMITED_QUEUE;
+#else
+      throw libfsw_exception(std::string(UNLIMITED_QUEUE_PROPERTY) +
+                             "=true requires FAN_UNLIMITED_QUEUE support in the build headers.");
+#endif
+    }
+
+    if (unlimited_marks)
+    {
+#if defined(FAN_UNLIMITED_MARKS)
+      init_flags |= FAN_UNLIMITED_MARKS;
+#else
+      throw libfsw_exception(std::string(UNLIMITED_MARKS_PROPERTY) +
+                             "=true requires FAN_UNLIMITED_MARKS support in the build headers.");
+#endif
+    }
+
+#if defined(FAN_REPORT_TID)
+    if (impl->process_kind == process_id_kind::tid) init_flags |= FAN_REPORT_TID;
+#endif
+
+    if (impl->report_pidfd)
+    {
+#if defined(FAN_REPORT_PIDFD)
+      init_flags |= FAN_REPORT_PIDFD;
+#else
+      throw libfsw_exception(_("fanotify pidfd reporting is not supported by the build headers."));
+#endif
+    }
+
+    scoped_fd fanotify_fd(fanotify_init(init_flags, O_RDONLY | O_CLOEXEC | O_LARGEFILE));
+    if (fanotify_fd.get() < 0)
+    {
+      const int fanotify_errno = errno;
+      fsw_log_perror("fanotify_init");
+      if (fanotify_errno == EPERM && (unlimited_queue || unlimited_marks))
+      {
+        throw libfsw_exception("fanotify.unlimited-queue=true or fanotify.unlimited-marks=true requires CAP_SYS_ADMIN.");
+      }
+
+      throw libfsw_exception(_("Cannot initialize fanotify."));
+    }
+
+    scoped_fd wake_fd(eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK));
+    if (wake_fd.get() < 0)
+    {
+      fsw_log_perror("eventfd");
+      throw libfsw_exception(_("Cannot initialize fanotify."));
+    }
+
+    scoped_fd epoll_fd(epoll_create1(EPOLL_CLOEXEC));
+    if (epoll_fd.get() < 0)
+    {
+      fsw_log_perror("epoll_create1");
+      throw libfsw_exception(_("Cannot initialize fanotify."));
+    }
+
+    add_epoll_interest(epoll_fd.get(), fanotify_fd.get());
+    add_epoll_interest(epoll_fd.get(), wake_fd.get());
+
+    impl->fanotify_fd = std::move(fanotify_fd);
+    impl->wake_fd = std::move(wake_fd);
+    impl->epoll_fd = std::move(epoll_fd);
+    impl->initialized = true;
+  }
+
+  bool fanotify_monitor::is_watched(const std::string& path) const
+  {
+    return impl->watched_paths.find(path) != impl->watched_paths.end();
+  }
+
+  bool fanotify_monitor::add_mark(const std::filesystem::path& path)
+  {
+    uint64_t event_mask =
+      FAN_MODIFY | FAN_CLOSE_WRITE | FAN_ATTRIB |
+      FAN_CREATE | FAN_DELETE | FAN_DELETE_SELF |
+      FAN_MOVED_FROM | FAN_MOVED_TO | FAN_MOVE_SELF |
+      FAN_ONDIR | FAN_EVENT_ON_CHILD;
+
+    if (watch_access)
+    {
+      event_mask |= FAN_ACCESS | FAN_OPEN | FAN_CLOSE_NOWRITE;
+    }
+
+    if (fanotify_mark(impl->fanotify_fd.get(),
+                      FAN_MARK_ADD,
+                      event_mask,
+                      AT_FDCWD,
+                      path.c_str()) != 0)
+    {
+      fsw_log_perror("fanotify_mark");
+      return false;
+    }
+
+    impl->watched_paths.insert(path.string());
+
+    std::string handle_key;
+    if (get_path_handle(path, handle_key))
+    {
+      impl->handle_to_path[handle_key] = path.string();
+    }
+
+    FSW_ELOGF(_("fanotify added: %s\n"), path.c_str());
+    return true;
+  }
+
+  void fanotify_monitor::scan(const std::filesystem::path& path, const bool accept_non_dirs)
+  {
+    try
+    {
+      auto status = std::filesystem::symlink_status(path);
+
+      if (!std::filesystem::exists(status)) return;
+
+      if (follow_symlinks && std::filesystem::is_symlink(status))
+      {
+        scan(std::filesystem::read_symlink(path), accept_non_dirs);
+        return;
+      }
+
+      const bool is_dir = std::filesystem::is_directory(status);
+      if (!is_dir && !accept_non_dirs) return;
+      if (!is_dir && directory_only) return;
+      if (!accept_path(path.string())) return;
+      if (is_watched(path.string())) return;
+      if (!add_mark(path)) return;
+      if (!recursive || !is_dir) return;
+
+      const auto entries = get_subdirectories(path);
+      for (const auto& entry : entries)
+      {
+        scan(entry, false);
+      }
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+      FSW_ELOGF(_("Filesystem error: %s"), e.what());
+    }
+  }
+
+  void fanotify_monitor::scan_root_paths()
+  {
+    for (const std::string& path : paths)
+    {
+      if (!is_watched(path)) scan(path);
+    }
+  }
+
+  void fanotify_monitor::process_pending_paths()
+  {
+    for (const auto& path : impl->paths_to_rescan)
+    {
+      scan(path);
+    }
+
+    impl->paths_to_rescan.clear();
+  }
+
+  void fanotify_monitor::process_synthetic_events()
+  {
+    for (const std::string& path : impl->paths_to_fire_create)
+    {
+      FSW_ELOGF(_("Synthetic event: processing directory: %s\n"), path.c_str());
+
+      const auto entries = get_directory_entries(path);
+
+      for (const auto& entry : entries)
+      {
+        std::vector<fsw_event_flag> flags{fsw_event_flag::Created};
+
+        try
+        {
+          if (entry.is_directory()) flags.push_back(fsw_event_flag::IsDir);
+        }
+        catch (const std::filesystem::filesystem_error& e)
+        {
+          FSW_ELOGF(_("Filesystem error: %s"), e.what());
+        }
+
+        impl->events.emplace_back(entry.path().string(), impl->curr_time, flags);
+      }
+    }
+
+    impl->paths_to_fire_create.clear();
+  }
+
+  void fanotify_monitor::process_events(char *buffer, ssize_t length)
+  {
+    time(&impl->curr_time);
+
+    for (auto *metadata = reinterpret_cast<struct fanotify_event_metadata *>(buffer);
+         FAN_EVENT_OK(metadata, length);
+         metadata = FAN_EVENT_NEXT(metadata, length))
+    {
+      if (metadata->vers != FANOTIFY_METADATA_VERSION)
+        throw libfsw_exception(_("fanotify metadata version mismatch."));
+
+      if (metadata->mask & FAN_Q_OVERFLOW)
+      {
+        notify_overflow("");
+        continue;
+      }
+
+      std::string path;
+      int pidfd = -1;
+      bool has_pidfd = false;
+
+      auto *info = reinterpret_cast<struct fanotify_event_info_header *>(
+        reinterpret_cast<char *>(metadata) + metadata->metadata_len);
+      char *info_end = reinterpret_cast<char *>(metadata) + metadata->event_len;
+
+      while (reinterpret_cast<char *>(info) + sizeof(*info) <= info_end &&
+             info->len >= sizeof(*info) &&
+             reinterpret_cast<char *>(info) + info->len <= info_end)
+      {
+        switch (info->info_type)
+        {
+        case FAN_EVENT_INFO_TYPE_DFID_NAME:
+        case FAN_EVENT_INFO_TYPE_DFID:
+        case FAN_EVENT_INFO_TYPE_FID:
+        {
+          auto *fid = reinterpret_cast<struct fanotify_event_info_fid *>(info);
+          auto *file_handle = reinterpret_cast<struct file_handle *>(fid->handle);
+          std::string handle_key = make_handle_key(&fid->fsid, sizeof(fid->fsid), file_handle);
+
+          auto cached_path = impl->handle_to_path.find(handle_key);
+          if (cached_path == impl->handle_to_path.end()) break;
+
+          path = cached_path->second;
+
+          if (info->info_type == FAN_EVENT_INFO_TYPE_DFID_NAME)
+          {
+            const char *name = reinterpret_cast<const char *>(
+              file_handle->f_handle + file_handle->handle_bytes);
+
+            if (name[0] != '\0' && std::strcmp(name, ".") != 0)
+            {
+              path = (std::filesystem::path(path) / name).string();
+            }
+          }
+
+          break;
+        }
+#if defined(FAN_EVENT_INFO_TYPE_PIDFD)
+        case FAN_EVENT_INFO_TYPE_PIDFD:
+        {
+          auto *pidfd_info = reinterpret_cast<struct fanotify_event_info_pidfd *>(info);
+          if (pidfd_info->pidfd >= 0)
+          {
+            pidfd = pidfd_info->pidfd;
+            has_pidfd = true;
+            impl->pidfds_to_close.push_back(pidfd);
+          }
+          break;
+        }
+#endif
+        default:
+          break;
+        }
+
+        info = reinterpret_cast<struct fanotify_event_info_header *>(
+          reinterpret_cast<char *>(info) + info->len);
+      }
+
+      if (path.empty())
+      {
+        FSW_ELOG(_("fanotify event path could not be reconstructed.\n"));
+        continue;
+      }
+
+      std::vector<fsw_event_flag> flags = flags_from_mask(metadata->mask);
+      if (flags.empty()) continue;
+
+      process_metadata process;
+      if (metadata->pid > 0)
+      {
+        process.kind = impl->process_kind;
+        process.id = metadata->pid;
+      }
+      process.pidfd = pidfd;
+      process.has_pidfd = has_pidfd;
+
+      if (recursive &&
+          is_directory_event(metadata->mask) &&
+          (metadata->mask & (FAN_CREATE | FAN_MOVED_TO)))
+      {
+        impl->paths_to_rescan.push_back(path);
+        impl->paths_to_fire_create.push_back(path);
+      }
+
+      impl->events.emplace_back(path, impl->curr_time, flags, 0, process);
+    }
+  }
+
+  void fanotify_monitor::notify_and_clear_events()
+  {
+    if (!impl->events.empty())
+    {
+      notify_events(impl->events);
+      impl->events.clear();
+    }
+
+    for (int pidfd : impl->pidfds_to_close)
+    {
+      close(pidfd);
+    }
+
+    impl->pidfds_to_close.clear();
+  }
+
+  void fanotify_monitor::on_stop()
+  {
+    if (!impl || impl->wake_fd.get() < 0) return;
+
+    uint64_t value = 1;
+    for (;;)
+    {
+      ssize_t write_count = write(impl->wake_fd.get(), &value, sizeof(value));
+
+      if (write_count == static_cast<ssize_t>(sizeof(value))) break;
+      if (write_count == -1 && errno == EINTR) continue;
+      if (write_count == -1 && errno == EAGAIN) break;
+
+      fsw_log_perror("write");
+      break;
+    }
+  }
+
+  void fanotify_monitor::run()
+  {
+    initialize();
+
+    const int timeout_ms = latency_to_timeout_ms(this->latency);
+    std::array<char, FANOTIFY_BUFFER_SIZE> buffer{};
+    std::array<struct epoll_event, EPOLL_EVENT_COUNT> epoll_events{};
+
+    for (;;)
+    {
+      std::unique_lock<std::mutex> run_guard(run_mutex);
+      if (should_stop) break;
+      run_guard.unlock();
+
+      process_pending_paths();
+      scan_root_paths();
+
+      if (impl->watched_paths.empty())
+      {
+        int rv = epoll_wait(impl->epoll_fd.get(),
+                            epoll_events.data(),
+                            epoll_events.size(),
+                            timeout_ms);
+
+        if (rv == -1)
+        {
+          if (errno == EINTR) continue;
+          fsw_log_perror("epoll_wait");
+          continue;
+        }
+
+        if (rv > 0)
+        {
+          for (int i = 0; i < rv; ++i)
+          {
+            if (epoll_events[i].data.fd == impl->wake_fd.get())
+            {
+              drain_eventfd(impl->wake_fd.get());
+              return;
+            }
+          }
+        }
+
+        continue;
+      }
+
+      int rv = epoll_wait(impl->epoll_fd.get(),
+                          epoll_events.data(),
+                          epoll_events.size(),
+                          timeout_ms);
+
+      if (rv == -1)
+      {
+        if (errno == EINTR) continue;
+        fsw_log_perror("epoll_wait");
+        continue;
+      }
+
+      if (rv == 0) continue;
+
+      bool wake_requested = false;
+
+      for (int i = 0; i < rv; ++i)
+      {
+        if (epoll_events[i].data.fd == impl->wake_fd.get())
+        {
+          drain_eventfd(impl->wake_fd.get());
+          wake_requested = true;
+          continue;
+        }
+
+        if (epoll_events[i].data.fd != impl->fanotify_fd.get())
+        {
+          continue;
+        }
+
+        for (;;)
+        {
+          ssize_t record_num = read(impl->fanotify_fd.get(),
+                                    buffer.data(),
+                                    buffer.size());
+
+          if (record_num == -1)
+          {
+            if (errno == EAGAIN) break;
+            if (errno == EINTR) continue;
+            fsw_log_perror("read");
+            throw libfsw_exception(_("read() on fanotify descriptor returned -1."));
+          }
+
+          if (record_num == 0) break;
+
+          process_events(buffer.data(), record_num);
+        }
+      }
+
+      notify_and_clear_events();
+      if (wake_requested) break;
+
+      process_pending_paths();
+      process_synthetic_events();
+      notify_and_clear_events();
+    }
+  }
+}

--- a/src/fswatch/libfswatch/src/libfswatch/c++/fanotify_monitor.hpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/fanotify_monitor.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Enrico M. Crisostomo
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file
+ * @brief Header of the fsw::fanotify_monitor class.
+ */
+
+#ifndef FSW_FANOTIFY_MONITOR_H
+#  define FSW_FANOTIFY_MONITOR_H
+
+#  include "monitor.hpp"
+#  include <string>
+#  include <vector>
+#  include <filesystem>
+#  include <memory>
+#  include <sys/types.h>
+
+namespace fsw
+{
+  struct fanotify_monitor_impl;
+
+  /**
+   * @brief Linux fanotify monitor.
+   *
+   * This monitor is backed by the Linux fanotify API and is available only on
+   * systems whose headers and C library expose the required fanotify features.
+   */
+  class fanotify_monitor : public monitor
+  {
+  public:
+    static constexpr const char *PROCESS_ID_PROPERTY = "fanotify.process-id";
+    static constexpr const char *REPORT_PIDFD_PROPERTY = "fanotify.report-pidfd";
+    static constexpr const char *UNLIMITED_QUEUE_PROPERTY = "fanotify.unlimited-queue";
+    static constexpr const char *UNLIMITED_MARKS_PROPERTY = "fanotify.unlimited-marks";
+
+    fanotify_monitor(std::vector<std::string> paths,
+                     FSW_EVENT_CALLBACK *callback,
+                     void *context = nullptr);
+
+    ~fanotify_monitor() override;
+
+  protected:
+    void run() override;
+    void on_stop() override;
+
+  private:
+    fanotify_monitor(const fanotify_monitor& orig) = delete;
+    fanotify_monitor& operator=(const fanotify_monitor& that) = delete;
+
+    void initialize();
+    void scan_root_paths();
+    void scan(const std::filesystem::path& path, bool accept_non_dirs = true);
+    bool add_mark(const std::filesystem::path& path);
+    bool is_watched(const std::string& path) const;
+    void process_pending_paths();
+    void process_synthetic_events();
+    void process_events(char *buffer, ssize_t length);
+    void notify_and_clear_events();
+
+    std::unique_ptr<fanotify_monitor_impl> impl;
+  };
+}
+
+#endif  /* FSW_FANOTIFY_MONITOR_H */

--- a/src/fswatch/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/fsevents_monitor.cpp
@@ -46,6 +46,7 @@ namespace fsw
     Impl& operator=(const Impl&) = delete;
 
     FSEventStreamRef stream = nullptr;
+    CFArrayRef paths_to_watch = nullptr;
 #ifdef HAVE_MACOS_GE_10_6
     dispatch_queue_t fsevents_queue = nullptr;
 #else
@@ -109,34 +110,25 @@ namespace fsw
   {
   }
 
+  fsevents_monitor::~fsevents_monitor() = default;
+
   void fsevents_monitor::run()
   {
     std::unique_lock<std::mutex> run_loop_lock(run_mutex);
 
     if (pImpl->stream) return;
 
-    // parsing paths
-    vector<CFStringRef> dirs;
+    pImpl->paths_to_watch = copy_cf_paths(paths);
+    if (!pImpl->paths_to_watch) return;
 
-    for (const string& path : paths)
-    {
-      dirs.push_back(CFStringCreateWithCString(nullptr,
-                                               path.c_str(),
-                                               kCFStringEncodingUTF8));
-    }
-
-    if (dirs.empty()) return;
-
-    CFArrayRef pathsToWatch =
-      CFArrayCreate(nullptr,
-                    reinterpret_cast<const void **> (&dirs[0]),
-                    dirs.size(),
-                    &kCFTypeArrayCallBacks);
-
-    create_stream(pathsToWatch);
+    create_stream(pImpl->paths_to_watch);
 
     if (!pImpl->stream)
+    {
+      CFRelease(pImpl->paths_to_watch);
+      pImpl->paths_to_watch = nullptr;
       throw libfsw_exception(_("Event stream could not be created."));
+    }
 
 #ifdef HAVE_MACOS_GE_10_6
     // Creating dispatch queue
@@ -186,6 +178,8 @@ namespace fsw
 #ifdef HAVE_MACOS_GE_10_6
     dispatch_release(pImpl->fsevents_queue);
 #endif
+    CFRelease(pImpl->paths_to_watch);
+    pImpl->paths_to_watch = nullptr;
     pImpl->stream = nullptr;
   }
 
@@ -242,10 +236,26 @@ namespace fsw
     for (size_t i = 0; i < numEvents; ++i)
     {
 #ifdef HAVE_MACOS_GE_10_13
-      auto path_info_dict = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex((CFArrayRef) eventPaths,
+      auto event_paths = static_cast<CFArrayRef>(eventPaths);
+      if (!event_paths)
+      {
+        continue;
+      }
+
+      auto path_info_dict = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(event_paths,
                                                                                 i));
+      if (!path_info_dict)
+      {
+        continue;
+      }
+
       auto path = static_cast<CFStringRef>(CFDictionaryGetValue(path_info_dict,
                                                                 kFSEventStreamEventExtendedDataPathKey));
+      if (!path)
+      {
+        continue;
+      }
+
       auto cf_inode = static_cast<CFNumberRef>(CFDictionaryGetValue(path_info_dict,
                                                                     kFSEventStreamEventExtendedFileIDKey));
 
@@ -261,8 +271,12 @@ namespace fsw
           continue;
       }
 
-      unsigned long inode;
-      CFNumberGetValue(cf_inode, kCFNumberLongType, &inode);
+      unsigned long inode = 0;
+      if (cf_inode)
+      {
+        CFNumberGetValue(cf_inode, kCFNumberLongType, &inode);
+      }
+
       events.emplace_back(std::string(path_buffer.data()),
                           curr_time,
                           decode_flags(eventFlags[i]),
@@ -289,6 +303,34 @@ namespace fsw
       return (!isatty(fileno(stdin)));
 
     return (no_defer == "true");
+  }
+
+  CFArrayRef fsevents_monitor::copy_cf_paths(const vector<string>& paths)
+  {
+    vector<CFStringRef> dirs;
+
+    for (const string& path : paths)
+    {
+      auto dir = CFStringCreateWithCString(nullptr,
+                                           path.c_str(),
+                                           kCFStringEncodingUTF8);
+      if (dir) dirs.push_back(dir);
+    }
+
+    if (dirs.empty()) return nullptr;
+
+    CFArrayRef pathsToWatch =
+      CFArrayCreate(nullptr,
+                    reinterpret_cast<const void **> (&dirs[0]),
+                    dirs.size(),
+                    &kCFTypeArrayCallBacks);
+
+    for (auto dir : dirs)
+    {
+      CFRelease(dir);
+    }
+
+    return pathsToWatch;
   }
 
   void fsevents_monitor::create_stream(CFArrayRef pathsToWatch)

--- a/src/fswatch/libfswatch/src/libfswatch/c++/fsevents_monitor.hpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/fsevents_monitor.hpp
@@ -28,6 +28,7 @@
 
 #  include "monitor.hpp"
 #  include <CoreServices/CoreServices.h>
+#  include <memory>
 
 namespace fsw
 {
@@ -67,6 +68,7 @@ namespace fsw
     fsevents_monitor(std::vector<std::string> paths,
                      FSW_EVENT_CALLBACK *callback,
                      void *context = nullptr);
+    ~fsevents_monitor() override;
     fsevents_monitor(const fsevents_monitor& orig) = delete;
     fsevents_monitor& operator=(const fsevents_monitor& that) = delete;
 
@@ -97,6 +99,7 @@ namespace fsw
                                   const FSEventStreamEventId eventIds[]);
 
     bool no_defer();
+    static CFArrayRef copy_cf_paths(const std::vector<std::string>& paths);
     void create_stream(CFArrayRef pathsToWatch);
   };
 }

--- a/src/fswatch/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/inotify_monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -13,11 +13,18 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
 #include <libfswatch/libfswatch_config.h>
 
 #include "libfswatch/gettext_defs.h"
 #include "inotify_monitor.hpp"
 #include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 #include <limits.h>
@@ -29,7 +36,8 @@
 #include <sstream>
 #include <ctime>
 #include <cmath>
-#include <sys/select.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
 #include "libfswatch_exception.hpp"
 #include "../c/libfswatch_log.h"
 #include "path_utils.hpp"
@@ -40,6 +48,8 @@ namespace fsw
   struct inotify_monitor_impl
   {
     int inotify_monitor_handle = -1;
+    int epoll_handle = -1;
+    int wake_handle = -1;
     std::vector<event> events;
     /*
      * A map of file names by descriptor is kept in sync because the name field
@@ -64,10 +74,80 @@ namespace fsw
     std::unordered_set<int> descriptors_to_remove;
     std::unordered_set<int> watches_to_remove;
     std::vector<std::string> paths_to_rescan;
+    std::vector<std::string> paths_to_fire_create;
     time_t curr_time;
   };
 
   static const unsigned int BUFFER_SIZE = (10 * ((sizeof(struct inotify_event)) + NAME_MAX + 1));
+  static const int EPOLL_EVENT_COUNT = 2;
+
+  struct scoped_fd
+  {
+    int fd = -1;
+
+    scoped_fd() = default;
+    explicit scoped_fd(int fd) : fd(fd) {}
+    scoped_fd(const scoped_fd&) = delete;
+    scoped_fd& operator=(const scoped_fd&) = delete;
+
+    ~scoped_fd()
+    {
+      if (fd >= 0) close(fd);
+    }
+
+    int get() const
+    {
+      return fd;
+    }
+
+    int release()
+    {
+      const int released = fd;
+      fd = -1;
+      return released;
+    }
+  };
+
+  static int latency_to_timeout_ms(double latency)
+  {
+    if (latency <= 0) return 0;
+    if (latency >= INT_MAX / 1000.0) return INT_MAX;
+
+    return static_cast<int>(std::ceil(latency * 1000.0));
+  }
+
+  static void add_epoll_interest(int epoll_fd, int fd)
+  {
+    struct epoll_event event {};
+    event.events = EPOLLIN;
+    event.data.fd = fd;
+
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &event) != 0)
+    {
+      fsw_log_perror("epoll_ctl");
+      throw libfsw_exception(_("Cannot initialize inotify."));
+    }
+  }
+
+  static void drain_eventfd(int fd)
+  {
+    for (;;)
+    {
+      uint64_t value = 0;
+      ssize_t read_count = read(fd, &value, sizeof(value));
+
+      if (read_count == static_cast<ssize_t>(sizeof(value))) continue;
+      if (read_count == -1 && errno == EINTR) continue;
+      if (read_count == -1 && errno == EAGAIN) break;
+      if (read_count == -1)
+      {
+        fsw_log_perror("read");
+        break;
+      }
+
+      break;
+    }
+  }
 
   inotify_monitor::inotify_monitor(std::vector<std::string> paths_to_monitor,
                                    FSW_EVENT_CALLBACK *callback,
@@ -75,13 +155,34 @@ namespace fsw
     monitor(paths_to_monitor, callback, context),
     impl(std::make_unique<inotify_monitor_impl>())
   {
-    impl->inotify_monitor_handle = inotify_init();
+    scoped_fd inotify_fd(inotify_init1(IN_CLOEXEC | IN_NONBLOCK));
 
-    if (impl->inotify_monitor_handle == -1)
+    if (inotify_fd.get() == -1)
     {
-      perror("inotify_init");
+      perror("inotify_init1");
       throw libfsw_exception(_("Cannot initialize inotify."));
     }
+
+    scoped_fd wake_fd(eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK));
+    if (wake_fd.get() == -1)
+    {
+      fsw_log_perror("eventfd");
+      throw libfsw_exception(_("Cannot initialize inotify."));
+    }
+
+    scoped_fd epoll_fd(epoll_create1(EPOLL_CLOEXEC));
+    if (epoll_fd.get() == -1)
+    {
+      fsw_log_perror("epoll_create1");
+      throw libfsw_exception(_("Cannot initialize inotify."));
+    }
+
+    add_epoll_interest(epoll_fd.get(), inotify_fd.get());
+    add_epoll_interest(epoll_fd.get(), wake_fd.get());
+
+    impl->inotify_monitor_handle = inotify_fd.release();
+    impl->wake_handle = wake_fd.release();
+    impl->epoll_handle = epoll_fd.release();
   }
 
   inotify_monitor::~inotify_monitor()
@@ -95,18 +196,34 @@ namespace fsw
     }
 
     // close inotify (removes watches)
-    if (impl->inotify_monitor_handle > 0)
+    if (impl->inotify_monitor_handle >= 0)
     {
       close(impl->inotify_monitor_handle);
+    }
+
+    if (impl->epoll_handle >= 0)
+    {
+      close(impl->epoll_handle);
+    }
+
+    if (impl->wake_handle >= 0)
+    {
+      close(impl->wake_handle);
     }
   }
 
   bool inotify_monitor::add_watch(const std::string& path)
   {
     // TODO: Consider optionally adding the IN_EXCL_UNLINK flag.
+    auto event_mask = IN_ALL_EVENTS;
+    if (!watch_access)
+    {
+      event_mask &= ~(IN_ACCESS | IN_CLOSE_NOWRITE | IN_OPEN);
+    }
+
     int inotify_desc = inotify_add_watch(impl->inotify_monitor_handle,
                                          path.c_str(),
-                                         IN_ALL_EVENTS);
+                                         event_mask);
 
     if (inotify_desc == -1)
     {
@@ -212,11 +329,6 @@ namespace fsw
       impl->events.emplace_back(impl->wd_to_path[event->wd], impl->curr_time, flags, event->cookie);
     }
 
-    // If a new directory has been created, it should be rescanned if the
-    if ((event->mask & IN_ISDIR) && (event->mask & IN_CREATE))
-    {
-      impl->paths_to_rescan.push_back(impl->wd_to_path[event->wd]);
-    }
   }
 
   void inotify_monitor::preprocess_node_event(const struct inotify_event *event)
@@ -241,6 +353,13 @@ namespace fsw
     {
       filename_stream << "/";
       filename_stream << event->name;
+    }
+
+    if ((event->mask & IN_ISDIR) && (event->mask & IN_CREATE))
+    {
+      const std::string created_dir_path = filename_stream.str();
+      impl->paths_to_rescan.push_back(created_dir_path);
+      impl->paths_to_fire_create.push_back(created_dir_path);
     }
 
     if (!flags.empty())
@@ -374,11 +493,57 @@ namespace fsw
     impl->paths_to_rescan.clear();
   }
 
+  void inotify_monitor::process_synthetic_events()
+  {
+    for (const std::string& path : impl->paths_to_fire_create)
+    {
+      FSW_ELOGF(_("Synthetic event: processing directory: %s\n"), path.c_str());
+
+      const auto entries = get_directory_entries(path);
+
+      for (const auto& entry : entries)
+      {
+        std::vector<fsw_event_flag> flags{fsw_event_flag::Created};
+
+        try
+        {
+          if (entry.is_directory()) flags.push_back(fsw_event_flag::IsDir);
+        }
+        catch (const std::filesystem::filesystem_error& e)
+        {
+          FSW_ELOGF(_("Filesystem error: %s"), e.what());
+        }
+
+        impl->events.emplace_back(entry.path().string(), impl->curr_time, flags);
+      }
+    }
+
+    impl->paths_to_fire_create.clear();
+  }
+
+  void inotify_monitor::on_stop()
+  {
+    if (!impl || impl->wake_handle < 0) return;
+
+    uint64_t value = 1;
+    for (;;)
+    {
+      ssize_t write_count = write(impl->wake_handle, &value, sizeof(value));
+
+      if (write_count == static_cast<ssize_t>(sizeof(value))) break;
+      if (write_count == -1 && errno == EINTR) continue;
+      if (write_count == -1 && errno == EAGAIN) break;
+
+      fsw_log_perror("write");
+      break;
+    }
+  }
+
   void inotify_monitor::run()
   {
-    char buffer[BUFFER_SIZE];
-    double sec;
-    double frac = modf(this->latency, &sec);
+    std::array<char, BUFFER_SIZE> buffer{};
+    std::array<struct epoll_event, EPOLL_EVENT_COUNT> epoll_events{};
+    const int timeout_ms = latency_to_timeout_ms(this->latency);
 
     for(;;)
     {
@@ -390,69 +555,76 @@ namespace fsw
 
       scan_root_paths();
 
-      // If no files can be watched, sleep and repeat the loop.
-      if (!impl->watched_descriptors.size())
-      {
-        sleep(latency);
-        continue;
-      }
-
-      // Use select to timeout on file descriptor read the amount specified by
+      // Use epoll to timeout on file descriptor read the amount specified by
       // the monitor latency.  This way, the monitor has a chance to update its
       // watches with at least the periodicity expected by the user.
-      fd_set set;
-      struct timeval timeout;
-
-      FD_ZERO(&set);
-      FD_SET(impl->inotify_monitor_handle, &set);
-      timeout.tv_sec = sec;
-      timeout.tv_usec = 1000 * 1000 * frac;
-
-      int rv = select(impl->inotify_monitor_handle + 1,
-                      &set,
-                      nullptr,
-                      nullptr,
-                      &timeout);
+      int rv = epoll_wait(impl->epoll_handle,
+                          epoll_events.data(),
+                          epoll_events.size(),
+                          timeout_ms);
 
       if (rv == -1)
       {
-	fsw_log_perror("select");
-	continue;
+        if (errno == EINTR) continue;
+        fsw_log_perror("epoll_wait");
+        continue;
       }
 
-      // In case of read timeout just repeat the loop.
+      // In case of wait timeout just repeat the loop.
       if (rv == 0) continue;
 
-      ssize_t record_num = read(impl->inotify_monitor_handle,
-                                buffer,
-                                BUFFER_SIZE);
+      bool wake_requested = false;
 
+      for (int i = 0; i < rv; ++i)
       {
-        std::ostringstream log;
-        log << _("Number of records: ") << record_num << "\n";
-        FSW_ELOG(log.str().c_str());
-      }
+        if (epoll_events[i].data.fd == impl->wake_handle)
+        {
+          drain_eventfd(impl->wake_handle);
+          wake_requested = true;
+          continue;
+        }
 
-      if (!record_num)
-      {
-        throw libfsw_exception(_("read() on inotify descriptor read 0 records."));
-      }
+        if (epoll_events[i].data.fd != impl->inotify_monitor_handle)
+        {
+          continue;
+        }
 
-      if (record_num == -1)
-      {
-        perror("read()");
-        throw libfsw_exception(_("read() on inotify descriptor returned -1."));
-      }
+        for (;;)
+        {
+          ssize_t record_num = read(impl->inotify_monitor_handle,
+                                    buffer.data(),
+                                    buffer.size());
 
-      time(&impl->curr_time);
+          {
+            std::ostringstream log;
+            log << _("Number of records: ") << record_num << "\n";
+            FSW_ELOG(log.str().c_str());
+          }
 
-      for (char *p = buffer; p < buffer + record_num;)
-      {
-        struct inotify_event const *event = reinterpret_cast<struct inotify_event *> (p);
+          if (!record_num)
+          {
+            throw libfsw_exception(_("read() on inotify descriptor read 0 records."));
+          }
 
-        preprocess_event(event);
+          if (record_num == -1)
+          {
+            if (errno == EAGAIN) break;
+            if (errno == EINTR) continue;
+            perror("read()");
+            throw libfsw_exception(_("read() on inotify descriptor returned -1."));
+          }
 
-        p += (sizeof(struct inotify_event)) + event->len;
+          time(&impl->curr_time);
+
+          for (char *p = buffer.data(); p < buffer.data() + record_num;)
+          {
+            struct inotify_event const *event = reinterpret_cast<struct inotify_event *> (p);
+
+            preprocess_event(event);
+
+            p += (sizeof(struct inotify_event)) + event->len;
+          }
+        }
       }
 
       if (!impl->events.empty())
@@ -461,7 +633,15 @@ namespace fsw
         impl->events.clear();
       }
 
-      sleep(latency);
+      process_pending_events();
+      process_synthetic_events();
+
+      if (!impl->events.empty())
+      {
+        notify_events(impl->events);
+        impl->events.clear();
+      }
+      if (wake_requested) break;
     }
   }
 }

--- a/src/fswatch/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/inotify_monitor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,7 +17,7 @@
  * @file
  * @brief Solaris/Illumos monitor.
  *
- * @copyright Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.8.0
@@ -71,6 +71,7 @@ namespace fsw
      * @see stop()
      */
     void run() override;
+    void on_stop() override;
 
   private:
     inotify_monitor(const inotify_monitor& orig) = delete;
@@ -84,6 +85,7 @@ namespace fsw
     void scan(const std::filesystem::path& path, const bool accept_non_dirs = true);
     bool add_watch(const std::string& path);
     void process_pending_events();
+    void process_synthetic_events();
     void remove_watch(int fd);
 
     std::unique_ptr<fsw::inotify_monitor_impl> impl;

--- a/src/fswatch/libfswatch/src/libfswatch/c++/monitor.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/monitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -30,6 +30,7 @@
 #include <ctime>
 #include <map>
 #include <set>
+#include <tuple>
 
 using namespace std::chrono;
 
@@ -352,18 +353,31 @@ monitor::~monitor()
       filtered_events.emplace_back(event.get_path(),
                                    event.get_time(),
                                    filtered_flags,
-                                   event.get_correlation_id());
+                                   event.get_correlation_id(),
+                                   process_metadata{event.get_process_id_kind(),
+                                                    event.get_process_id(),
+                                                    event.get_process_pidfd(),
+                                                    event.has_process_pidfd()});
     }
 
     if (bubble_events)
     {
-      // Bubble events by ({time, path})
-      std::map<std::pair<time_t, std::string>, std::set<fsw_event_flag>> bubbled_events;
+      // Bubble events by stable event identity.
+      using bubble_key =
+        std::tuple<time_t, std::string, unsigned long, process_id_kind, long long, int, bool>;
+
+      std::map<bubble_key, std::set<fsw_event_flag>> bubbled_events;
 
       for (auto const& event : filtered_events)
       {
         const auto& flags = event.get_flags();
-        bubbled_events[{event.get_time(), event.get_path()}].insert(flags.begin(), flags.end());
+        bubbled_events[{event.get_time(),
+                        event.get_path(),
+                        event.get_correlation_id(),
+                        event.get_process_id_kind(),
+                        event.get_process_id(),
+                        event.get_process_pidfd(),
+                        event.has_process_pidfd()}].insert(flags.begin(), flags.end());
       }
 
       filtered_events.clear();
@@ -372,7 +386,17 @@ monitor::~monitor()
         std::vector<fsw_event_flag> bubbled_flags(flags.size());
         std::move(flags.begin(), flags.end(), bubbled_flags.begin());
 
-        filtered_events.emplace_back(bubble_key.second, bubble_key.first, bubbled_flags);
+        process_metadata process;
+        process.kind = std::get<3>(bubble_key);
+        process.id = std::get<4>(bubble_key);
+        process.pidfd = std::get<5>(bubble_key);
+        process.has_pidfd = std::get<6>(bubble_key);
+
+        filtered_events.emplace_back(std::get<1>(bubble_key),
+                                     std::get<0>(bubble_key),
+                                     bubbled_flags,
+                                     std::get<2>(bubble_key),
+                                     process);
       }
     }
 

--- a/src/fswatch/libfswatch/src/libfswatch/c++/monitor_factory.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/monitor_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2021 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -27,8 +27,11 @@
 #if defined(HAVE_PORT_H)
   #include "fen_monitor.hpp"
 #endif
-#if defined(HAVE_SYS_INOTIFY_H)
+#if defined(HAVE_INOTIFY_MONITOR)
   #include "inotify_monitor.hpp"
+#endif
+#if defined(HAVE_FANOTIFY)
+  #include "fanotify_monitor.hpp"
 #endif
 #if defined(HAVE_WINDOWS)
   #include "windows_monitor.hpp"
@@ -49,7 +52,7 @@ namespace fsw
     type = fsw_monitor_type::kqueue_monitor_type;
 #elif defined(HAVE_PORT_H)
     type = fsw_monitor_type::fen_monitor_type;
-#elif defined(HAVE_SYS_INOTIFY_H)
+#elif defined(HAVE_INOTIFY_MONITOR)
     type = fsw_monitor_type::inotify_monitor_type;
 #elif defined(HAVE_WINDOWS)
     type = fsw_monitor_type::windows_monitor_type;
@@ -80,9 +83,13 @@ namespace fsw
 #if defined(HAVE_SYS_EVENT_H)
       case kqueue_monitor_type:return new kqueue_monitor(paths, callback, context);
 #endif
-#if defined(HAVE_SYS_INOTIFY_H)
+#if defined(HAVE_INOTIFY_MONITOR)
       case inotify_monitor_type:
         return new inotify_monitor(paths, callback, context);
+#endif
+#if defined(HAVE_FANOTIFY)
+      case fanotify_monitor_type:
+        return new fanotify_monitor(paths, callback, context);
 #endif
 #if defined(HAVE_WINDOWS)
       case windows_monitor_type:
@@ -114,8 +121,11 @@ namespace fsw
 #if defined(HAVE_PORT_H)
     creator_by_string_set[fsw_quote(fen_monitor)] = fsw_monitor_type::fen_monitor_type;
 #endif
-#if defined(HAVE_SYS_INOTIFY_H)
+#if defined(HAVE_INOTIFY_MONITOR)
     creator_by_string_set[fsw_quote(inotify_monitor)] = fsw_monitor_type::inotify_monitor_type;
+#endif
+#if defined(HAVE_FANOTIFY)
+    creator_by_string_set[fsw_quote(fanotify_monitor)] = fsw_monitor_type::fanotify_monitor_type;
 #endif
 #if defined(HAVE_WINDOWS)
     creator_by_string_set[fsw_quote(windows_monitor)] = fsw_monitor_type::windows_monitor_type;

--- a/src/fswatch/libfswatch/src/libfswatch/c++/path_utils.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/path_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -28,11 +28,11 @@ namespace fsw
   std::vector<std::filesystem::directory_entry> get_directory_entries(const std::filesystem::path& path)
   {
     std::vector<std::filesystem::directory_entry> entries;
-    // Reserve capacity to optimize memory allocation
-    entries.reserve(std::distance(std::filesystem::directory_iterator(path), std::filesystem::directory_iterator{}));
 
     try
     {
+      entries.reserve(std::distance(std::filesystem::directory_iterator(path), std::filesystem::directory_iterator{}));
+
       for (const auto& entry : std::filesystem::directory_iterator(path))
         entries.emplace_back(entry);
     }

--- a/src/fswatch/libfswatch/src/libfswatch/c++/string/string_utils.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c++/string/string_utils.cpp
@@ -26,6 +26,7 @@ namespace fsw
   {
     string vstring_from_format(const char *format, va_list args)
     {
+      if (!format) return string();
       size_t current_buffer_size = 0;
       int required_chars = 512;
 

--- a/src/fswatch/libfswatch/src/libfswatch/c/cevent.h
+++ b/src/fswatch/libfswatch/src/libfswatch/c/cevent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -19,7 +19,7 @@
  *
  * This header file defines the event types of the `libfswatch` API.
  *
- * @copyright Copyright (c) 2014-2015 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 13:1:0
@@ -30,6 +30,7 @@
 
 #  include <time.h>
 #  include <limits.h>
+#  include <stdbool.h>
 #  include "libfswatch_types.h"
 
 #  ifdef __cplusplus
@@ -124,6 +125,36 @@ extern "C"
   } fsw_cevent;
 
   /**
+   * @brief Type of process identifier associated with an event.
+   */
+  enum fsw_process_id_kind
+  {
+    FSW_PROCESS_ID_NONE = 0, /**< No process attribution is available. */
+    FSW_PROCESS_ID_PID,      /**< The identifier is a process ID. */
+    FSW_PROCESS_ID_TID       /**< The identifier is a thread ID. */
+  };
+
+  /**
+   * A file change event with extended metadata.
+   *
+   * This type is additive and preserves the ABI of fsw_cevent.  The process
+   * file descriptor is owned by libfswatch and is valid only while the
+   * callback is executing.
+   */
+  typedef struct fsw_cevent_v2
+  {
+    char * path;
+    time_t evt_time;
+    enum fsw_event_flag * flags;
+    unsigned int flags_num;
+    unsigned long correlation_id;
+    enum fsw_process_id_kind process_id_kind;
+    long long process_id;
+    int process_pidfd;
+    bool has_process_pidfd;
+  } fsw_cevent_v2;
+
+  /**
    * A function pointer of type FSW_CEVENT_CALLBACK is used by the API as a
    * callback to provide information about received events.  The callback is
    * passed the following arguments:
@@ -138,6 +169,13 @@ extern "C"
   typedef void (*FSW_CEVENT_CALLBACK)(fsw_cevent const *const events,
                                       const unsigned int event_num,
                                       void *data);
+
+  /**
+   * A callback receiving events with extended metadata.
+   */
+  typedef void (*FSW_CEVENT_CALLBACK_V2)(fsw_cevent_v2 const *const events,
+                                         const unsigned int event_num,
+                                         void *data);
 
 #  ifdef __cplusplus
 }

--- a/src/fswatch/libfswatch/src/libfswatch/c/cmonitor.h
+++ b/src/fswatch/libfswatch/src/libfswatch/c/cmonitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2021 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -17,7 +17,7 @@
  * @file
  * @brief Header of the `libfswatch` library defining the monitor types.
  *
- * @copyright Copyright (c) 2014-2016 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.8.0
@@ -48,7 +48,8 @@ extern "C"
     inotify_monitor_type,            /**< Linux `inotify` monitor. */
     windows_monitor_type,            /**< Windows monitor. */
     poll_monitor_type,               /**< `stat()`-based poll monitor. */
-    fen_monitor_type                 /**< Solaris/Illumos monitor. */
+    fen_monitor_type,                /**< Solaris/Illumos monitor. */
+    fanotify_monitor_type            /**< Linux `fanotify` monitor. */
   };
 
 #  ifdef __cplusplus

--- a/src/fswatch/libfswatch/src/libfswatch/c/libfswatch.cpp
+++ b/src/fswatch/libfswatch/src/libfswatch/c/libfswatch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,7 +16,7 @@
 /**
  * @file
  * @brief Main `libfswatch` source file.
- * @copyright Copyright (c) 2014-2024 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.17.0
@@ -459,6 +459,7 @@ using FSW_SESSION = struct FSW_SESSION
   fsw_monitor_type type;
   fsw::monitor *monitor;
   FSW_CEVENT_CALLBACK callback;
+  FSW_CEVENT_CALLBACK_V2 callback_v2;
   double latency;
   bool allow_overflow;
   bool recursive;
@@ -499,6 +500,7 @@ using fsw_callback_context = struct fsw_callback_context
 {
   FSW_HANDLE handle;
   FSW_CEVENT_CALLBACK callback;
+  FSW_CEVENT_CALLBACK_V2 callback_v2;
   void *data;
 };
 
@@ -510,6 +512,77 @@ void libfsw_cpp_callback_proxy(const std::vector<event>& events,
     throw int(FSW_ERR_MISSING_CONTEXT);
 
   const fsw_callback_context *context = static_cast<fsw_callback_context *> (context_ptr);
+
+  if (context->callback_v2)
+  {
+    auto *const cevents = static_cast<fsw_cevent_v2 *> (malloc(
+      sizeof(fsw_cevent_v2) * events.size()));
+
+    if (cevents == nullptr)
+      throw int(FSW_ERR_MEMORY);
+
+    for (unsigned int i = 0; i < events.size(); ++i)
+    {
+      fsw_cevent_v2 *cevt = &cevents[i];
+      const event& evt = events[i];
+
+      const string path = evt.get_path();
+      cevt->path = static_cast<char *> (malloc(path.length() + 1));
+      if (!cevt->path) throw int(FSW_ERR_MEMORY);
+
+      strncpy(cevt->path, path.c_str(), path.length());
+      cevt->path[path.length()] = '\0';
+      cevt->evt_time = evt.get_time();
+      cevt->correlation_id = evt.get_correlation_id();
+
+      switch (evt.get_process_id_kind())
+      {
+      case process_id_kind::pid:
+        cevt->process_id_kind = FSW_PROCESS_ID_PID;
+        break;
+      case process_id_kind::tid:
+        cevt->process_id_kind = FSW_PROCESS_ID_TID;
+        break;
+      case process_id_kind::none:
+        cevt->process_id_kind = FSW_PROCESS_ID_NONE;
+        break;
+      }
+
+      cevt->process_id = evt.get_process_id();
+      cevt->process_pidfd = evt.get_process_pidfd();
+      cevt->has_process_pidfd = evt.has_process_pidfd();
+
+      const vector<fsw_event_flag> flags = evt.get_flags();
+      cevt->flags_num = flags.size();
+
+      if (!cevt->flags_num) cevt->flags = nullptr;
+      else
+      {
+        cevt->flags =
+          static_cast<fsw_event_flag *> (
+            malloc(sizeof(fsw_event_flag) * cevt->flags_num));
+        if (!cevt->flags) throw int(FSW_ERR_MEMORY);
+      }
+
+      for (unsigned int e = 0; e < cevt->flags_num; ++e)
+      {
+        cevt->flags[e] = flags[e];
+      }
+    }
+
+    (*(context->callback_v2))(cevents, events.size(), context->data);
+
+    for (unsigned int i = 0; i < events.size(); ++i)
+    {
+      fsw_cevent_v2 *cevt = &cevents[i];
+
+      if (cevt->flags) free(static_cast<void *> (cevt->flags));
+      free(static_cast<void *> (cevt->path));
+    }
+
+    free(static_cast<void *> (cevents));
+    return;
+  }
 
   auto *const cevents = static_cast<fsw_cevent *> (malloc(
     sizeof(fsw_cevent) * events.size()));
@@ -526,8 +599,7 @@ void libfsw_cpp_callback_proxy(const std::vector<event>& events,
     const string path = evt.get_path();
 
     // Copy std::string into char * buffer and null-terminate it.
-    cevt->path = static_cast<char *> (malloc(
-      sizeof(char *) * (path.length() + 1)));
+    cevt->path = static_cast<char *> (malloc(path.length() + 1));
     if (!cevt->path) throw int(FSW_ERR_MEMORY);
 
     strncpy(cevt->path, path.c_str(), path.length());
@@ -582,7 +654,7 @@ int create_monitor(const FSW_HANDLE handle, const fsw_monitor_type type)
     FSW_SESSION *session = get_session(handle);
 
     // Check sufficient data is present to build a monitor.
-    if (!session->callback)
+    if (!session->callback && !session->callback_v2)
       return fsw_set_last_error(int(FSW_ERR_CALLBACK_NOT_SET));
 
     if (session->monitor)
@@ -594,6 +666,7 @@ int create_monitor(const FSW_HANDLE handle, const fsw_monitor_type type)
     auto *context_ptr = new fsw_callback_context{};
     context_ptr->handle = session;
     context_ptr->callback = session->callback;
+    context_ptr->callback_v2 = session->callback_v2;
     context_ptr->data = session->data;
 
     monitor *current_monitor = monitor_factory::create_monitor(type,
@@ -647,6 +720,22 @@ FSW_STATUS fsw_set_callback(const FSW_HANDLE handle,
 
   FSW_SESSION *session = get_session(handle);
   session->callback = callback;
+  session->callback_v2 = nullptr;
+  session->data = data;
+
+  return fsw_set_last_error(FSW_OK);
+}
+
+FSW_STATUS fsw_set_callback_v2(const FSW_HANDLE handle,
+                               const FSW_CEVENT_CALLBACK_V2 callback,
+                               void *data)
+{
+  if (!callback)
+    return fsw_set_last_error(int(FSW_ERR_INVALID_CALLBACK));
+
+  FSW_SESSION *session = get_session(handle);
+  session->callback = nullptr;
+  session->callback_v2 = callback;
   session->data = data;
 
   return fsw_set_last_error(FSW_OK);

--- a/src/fswatch/libfswatch/src/libfswatch/c/libfswatch.h
+++ b/src/fswatch/libfswatch/src/libfswatch/c/libfswatch.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022 Enrico M. Crisostomo
+ * Copyright (c) 2014-2026 Enrico M. Crisostomo
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -19,7 +19,7 @@
  *
  * This header file defines the API of the `libfswatch` library.
  *
- * @copyright Copyright (c) 2014-2022 Enrico M. Crisostomo
+ * @copyright Copyright (c) 2014-2026 Enrico M. Crisostomo
  * @license GNU General Public License v. 3.0
  * @author Enrico M. Crisostomo
  * @version 1.8.0
@@ -127,6 +127,17 @@ extern "C"
   FSW_STATUS fsw_set_callback(const FSW_HANDLE handle,
                               const FSW_CEVENT_CALLBACK callback,
                               void * data);
+
+  /**
+   * Sets the callback the monitor invokes when events with extended metadata
+   * are received.  This additive callback receives correlation and optional
+   * process attribution fields without changing the ABI of fsw_cevent.
+   *
+   * See cevent.h for the definition of FSW_CEVENT_CALLBACK_V2.
+   */
+  FSW_STATUS fsw_set_callback_v2(const FSW_HANDLE handle,
+                                 const FSW_CEVENT_CALLBACK_V2 callback,
+                                 void * data);
 
   /**
    * Sets the latency of the monitor.  By default, the latency is set to 1 s.

--- a/tools/update_libfswatch.sh
+++ b/tools/update_libfswatch.sh
@@ -4,7 +4,7 @@
 # Usage: ./tools/update_libfswatch.sh [version/commit/tag]
 #
 # This script reproduces how to get the current vendored code from the
-# upstream libfswatch repository.
+# upstream libfswatch repository and applies local patches.
 
 set -e
 
@@ -81,24 +81,49 @@ find "${STAGING_DIR}" -name "Makefile.am" -delete
 
 echo ""
 
-# Step 3: Replace vendored code
-echo -e "${YELLOW}Step 3: Updating vendored code...${NC}"
+# Step 3: Apply patches specific to watcher package
+echo -e "${YELLOW}Step 3: Applying patches for watcher package...${NC}"
+
+# Patch: Avoid GCC -Wformat-truncation "null format string" warning in
+# string_utils.cpp by adding an explicit null check on the format argument
+# before the vsnprintf call. Surfaces in stricter CRAN/rhub Linux builds.
+echo "Applying string_utils.cpp null-format guard..."
+STRING_UTILS="${STAGING_DIR}/libfswatch/src/libfswatch/c++/string/string_utils.cpp"
+
+if [ -f "${STRING_UTILS}" ]; then
+  if ! grep -q "if (!format) return" "${STRING_UTILS}"; then
+    sed -i.bak 's|^      size_t current_buffer_size = 0;$|      if (!format) return string();\
+      size_t current_buffer_size = 0;|' "${STRING_UTILS}"
+    rm -f "${STRING_UTILS}.bak"
+    echo -e "${GREEN}  ✓ Null-format guard applied${NC}"
+  else
+    echo -e "${GREEN}  ✓ Null-format guard already present${NC}"
+  fi
+else
+  echo -e "${YELLOW}  ⚠ string_utils.cpp not found, skipping patch${NC}"
+fi
+
+echo ""
+
+# Step 4: Replace vendored code
+echo -e "${YELLOW}Step 4: Updating vendored code...${NC}"
 rm -rf "${TARGET_DIR}"
 mv "${STAGING_DIR}" "${TARGET_DIR}"
 echo -e "${GREEN}Vendored code updated successfully!${NC}"
 echo ""
 
-# Step 4: Clean up
-echo -e "${YELLOW}Step 4: Cleaning up...${NC}"
+# Step 5: Clean up
+echo -e "${YELLOW}Step 5: Cleaning up...${NC}"
 cd "$(dirname "${WORK_DIR}")"
 rm -rf "${WORK_DIR}"
 echo -e "${GREEN}Temporary files removed${NC}"
 echo ""
 
-# Step 5: Show summary
+# Step 6: Show summary
 echo -e "${GREEN}=== Update Complete ===${NC}"
 echo ""
 echo "Summary:"
 echo "  - Updated from commit: ${CURRENT_COMMIT}"
 echo "  - Updated from tag: ${CURRENT_TAG}"
+echo "  - Patches applied: string_utils.cpp null-format guard"
 echo ""

--- a/tools/update_libfswatch.sh
+++ b/tools/update_libfswatch.sh
@@ -3,8 +3,8 @@
 # Script to update vendored libfswatch source code
 # Usage: ./tools/update_libfswatch.sh [version/commit/tag]
 #
-# This script reproduces how to get the current vendored code from the 
-# upstream libfswatch repository and applies necessary patches for R package use.
+# This script reproduces how to get the current vendored code from the
+# upstream libfswatch repository.
 
 set -e
 
@@ -81,57 +81,24 @@ find "${STAGING_DIR}" -name "Makefile.am" -delete
 
 echo ""
 
-# Step 3: Apply patches specific to watcher package
-echo -e "${YELLOW}Step 3: Applying patches for watcher package...${NC}"
-
-# Patch 1: Fix Windows latency issue (use std::this_thread::sleep_for instead of sleep)
-# Note: Future versions may include this fix upstream (PR #340 was merged to master)
-echo "Applying Windows latency fix..."
-WINDOWS_MONITOR="${STAGING_DIR}/libfswatch/src/libfswatch/c++/windows_monitor.cpp"
-
-if [ -f "${WINDOWS_MONITOR}" ]; then
-  # Add required headers if not present
-  if ! grep -q "include <thread>" "${WINDOWS_MONITOR}"; then
-    sed -i.bak '/^#  include <cstdio>/a\
-#  include <thread>\
-#  include <chrono>
-' "${WINDOWS_MONITOR}"
-    rm -f "${WINDOWS_MONITOR}.bak"
-  fi
-  
-  # Replace sleep() with std::this_thread::sleep_for (only if not already patched)
-  if grep -q "sleep(latency)" "${WINDOWS_MONITOR}"; then
-    sed -i.bak 's/sleep(latency)/std::this_thread::sleep_for(std::chrono::milliseconds((long long) (latency * 1000)))/' "${WINDOWS_MONITOR}"
-    rm -f "${WINDOWS_MONITOR}.bak"
-    echo -e "${GREEN}  ✓ Windows latency fix applied${NC}"
-  else
-    echo -e "${GREEN}  ✓ Windows latency fix already present${NC}"
-  fi
-else
-  echo -e "${YELLOW}  ⚠ windows_monitor.cpp not found, skipping patch${NC}"
-fi
-
-echo ""
-
-# Step 4: Replace vendored code
-echo -e "${YELLOW}Step 4: Updating vendored code...${NC}"
+# Step 3: Replace vendored code
+echo -e "${YELLOW}Step 3: Updating vendored code...${NC}"
 rm -rf "${TARGET_DIR}"
 mv "${STAGING_DIR}" "${TARGET_DIR}"
 echo -e "${GREEN}Vendored code updated successfully!${NC}"
 echo ""
 
-# Step 5: Clean up
-echo -e "${YELLOW}Step 5: Cleaning up...${NC}"
+# Step 4: Clean up
+echo -e "${YELLOW}Step 4: Cleaning up...${NC}"
 cd "$(dirname "${WORK_DIR}")"
 rm -rf "${WORK_DIR}"
 echo -e "${GREEN}Temporary files removed${NC}"
 echo ""
 
-# Step 6: Show summary
+# Step 5: Show summary
 echo -e "${GREEN}=== Update Complete ===${NC}"
 echo ""
 echo "Summary:"
 echo "  - Updated from commit: ${CURRENT_COMMIT}"
 echo "  - Updated from tag: ${CURRENT_TAG}"
-echo "  - Patches applied: Windows latency fix"
 echo ""


### PR DESCRIPTION
Note: we maintain our own null format string guard in `string_utils.cpp` out of prudence (may trigger under GCC-ASAN).